### PR TITLE
Set initial viewport for better mobile view

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,6 +6,7 @@
         <link rel="stylesheet" href="Leaflet-0.7.3/leaflet.css"/>
         <link rel="stylesheet" href="Leaflet.awesome-markers-2.0.2/leaflet.awesome-markers.css"/>
         <link rel="stylesheet" href="http://maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css"/>
+        <meta name="viewport" content="initial-scale=1,width=device-width">
         <style>
             html, body, #map {
                 height: 100%;

--- a/index.html
+++ b/index.html
@@ -292,7 +292,7 @@
             </form>
             <p>Ein Projekt des <a href="http://codefor.de/karlsruhe">Open Knowledge Lab Karlsruhe</a>.
             <a href="http://www.karlsruhe.de/b3/maerkte/wochenmarkte.de">Daten</a> von der Stadt
-            Karlsruhe. <a href="https://github.com/CodeforKarlsruhe/wo-ist-markt">Code</a> auf GiHub.</p>
+            Karlsruhe. <a href="https://github.com/CodeforKarlsruhe/wo-ist-markt">Code</a> auf GitHub.</p>
         </div>
     </body>
 </html>


### PR DESCRIPTION
Before:
![screenshot_2015-07-09-07-54-53](https://cloud.githubusercontent.com/assets/1096357/8588942/96247422-2610-11e5-9b5d-803b42977f85.png)
After:
![screenshot_2015-07-09-07-55-41](https://cloud.githubusercontent.com/assets/1096357/8588946/9831690a-2610-11e5-85d7-3148e28280bf.png)
By setting the `viewport` property it can be made sure that the map has bigger controls on mobile which makes it much easier to use.

I also fixed a small typo.
