### PR TITLE
OpenStreetMap opening hours format

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,6 +11,10 @@
         <script src="jquery-1.11.2.min.js"></script>
         <script src="Leaflet-0.7.3/leaflet.js"></script>
         <script src="Leaflet.awesome-markers-2.0.2/leaflet.awesome-markers.min.js"></script>
+        <script src="http://openingh.openstreetmap.de/evaluation_tool/node_modules/suncalc/suncalc.js"></script>
+        <script src="http://openingh.openstreetmap.de/evaluation_tool/opening_hours.js"></script>
+        <script src="http://momentjs.com/downloads/moment.min.js"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/moment-range/2.0.3/moment-range.min.js"></script>
         <script src="js/main.js"></script>
     </head>
     <body>

--- a/markt.json
+++ b/markt.json
@@ -1,82 +1,130 @@
 {
     "Bauernmarkt Durlach": {
-        "opening_hours": "We 07:30-14:00",
+        "coordinates": [
+            48.9988247,
+            8.4708768
+        ],
         "location": "Am Saumarkt",
-        "coordinates": [48.9988247, 8.4708768]
+        "opening_hours": "We 07:30-14:00"
     },
     "Daxlanden": {
-        "opening_hours": "Tu, Fr 07:30-14:00",
+        "coordinates": [
+            49.0046859,
+            8.3323837
+        ],
         "location": "Vor der Heilig-Geist-Kirche",
-        "coordinates": [49.0046859, 8.3323837]
+        "opening_hours": "Tu, Fr 07:30-14:00"
     },
     "Durlach": {
-        "opening_hours": "Mo-Sa 07:30-14:00",
+        "coordinates": [
+            48.9991056,
+            8.4714722
+        ],
         "location": "Auf dem Marktplatz",
-        "coordinates": [48.9991056, 8.4714722]
+        "opening_hours": "Mo-Sa 07:30-14:00"
     },
     "Gottesauer Platz": {
-        "opening_hours": "Mo, We, Fr 07:30-14:00",
+        "coordinates": [
+            49.0074213,
+            8.4237841
+        ],
         "location": null,
-        "coordinates": [49.0074213, 8.4237841]
-    },
-    "Gutenbergplatz": {
-        "opening_hours": "Tu, Th, Sa 07:30-14:00",
-        "location": null,
-        "coordinates": [49.008835, 8.375717]
+        "opening_hours": "Mo, We, Fr 07:30-14:00"
     },
     "Grünwinkel": {
-        "opening_hours": "Th 14:00-18:30",
+        "coordinates": [
+            49.00252,
+            8.35588
+        ],
         "location": "Auf dem Robert-Sinner-Platz",
-        "coordinates": [49.00252, 8.35588]
+        "opening_hours": "Th 14:00-18:30"
+    },
+    "Gutenbergplatz": {
+        "coordinates": [
+            49.008835,
+            8.375717
+        ],
+        "location": null,
+        "opening_hours": "Tu, Th, Sa 07:30-14:00"
     },
     "Knielingen": {
-        "opening_hours": "We, Sa 07:30-14:00; Fr 07:30-16:00",
+        "coordinates": [
+            49.030625,
+            8.34064
+        ],
         "location": "Auf dem Elsässer Platz",
-        "coordinates": [49.030625, 8.340640]
+        "opening_hours": "We, Sa 07:30-14:00; Fr 07:30-16:00"
     },
     "Kronenplatz": {
-        "opening_hours": "Mo-Fr 09:00-20:00; Sa 09:00-16:00",
+        "coordinates": [
+            49.00869,
+            8.409358
+        ],
         "location": null,
-        "coordinates": [49.008690, 8.409358]
+        "opening_hours": "Mo-Fr 09:00-20:00; Sa 09:00-16:00"
     },
     "Mühlburg": {
-        "opening_hours": "Fr 07:30-14:00",
+        "coordinates": [
+            49.010222,
+            8.358549
+        ],
         "location": "Am Entenfang",
-        "coordinates": [49.010222, 8.358549]
+        "opening_hours": "Fr 07:30-14:00"
     },
     "Neureut": {
-        "opening_hours": "Fr 07:30-18:00",
+        "coordinates": [
+            49.0445057,
+            8.382284
+        ],
         "location": "Auf dem Neureuter Platz",
-        "coordinates": [49.0445057, 8.382284]
+        "opening_hours": "Fr 07:30-18:00"
     },
     "Nordweststadt": {
-        "opening_hours": "Tu, Sa 07:30-14:00",
+        "coordinates": [
+            49.0291955,
+            8.3700837
+        ],
         "location": "Auf dem Walther-Rathenau-Platz",
-        "coordinates": [49.0291955, 8.3700837]
+        "opening_hours": "Tu, Sa 07:30-14:00"
     },
     "Oberreut": {
-        "opening_hours": "Fr 14:00-18:30",
+        "coordinates": [
+            48.9857738,
+            8.3621401
+        ],
         "location": "Auf dem Julius-Leber-Platz",
-        "coordinates": [48.9857738, 8.3621401]
+        "opening_hours": "Fr 14:00-18:30"
     },
     "Rüppurr": {
-        "opening_hours": "We, Sa 07:30-14:00",
+        "coordinates": [
+            48.9713553,
+            8.4050009
+        ],
         "location": "Vor der Christ-König-Kirche",
-        "coordinates": [48.9713553, 8.4050009]
+        "opening_hours": "We, Sa 07:30-14:00"
     },
     "Stephanplatz": {
-        "opening_hours": "Mo, We, Fr 07:30-14:00",
+        "coordinates": [
+            49.0086757,
+            8.3940901
+        ],
         "location": null,
-        "coordinates": [49.0086757, 8.3940901]
+        "opening_hours": "Mo, We, Fr 07:30-14:00"
     },
     "Waldstadt": {
-        "opening_hours": "We 14:00-18:30; Fr 12:00-18:30; Sa 07:30-14:00",
+        "coordinates": [
+            49.0347051,
+            8.4441821
+        ],
         "location": "Am Waldstadtzentrum",
-        "coordinates": [49.0347051, 8.4441821]
+        "opening_hours": "We 14:00-18:30; Fr 12:00-18:30; Sa 07:30-14:00"
     },
     "Werderplatz": {
-        "opening_hours": "Tu, Fr, Sa 07:30-14:00",
+        "coordinates": [
+            49.0015128,
+            8.4069493
+        ],
         "location": null,
-        "coordinates": [49.0015128, 8.4069493]
+        "opening_hours": "Tu, Fr, Sa 07:30-14:00"
     }
 }

--- a/markt.json
+++ b/markt.json
@@ -1,224 +1,80 @@
 {
     "Bauernmarkt Durlach": {
-        "days": [
-            null,
-            null,
-            [[7, 30], [14, 0]],
-            null,
-            null,
-            null,
-            null
-        ],
         "opening_hours": "We 07:30-14:00",
         "location": "Am Saumarkt",
         "coordinates": [48.9988247, 8.4708768]
     },
     "Daxlanden": {
-        "days": [
-            null,
-            [[7, 30], [14, 0]],
-            null,
-            null,
-            [[7, 30], [14, 0]],
-            null,
-            null
-        ],
         "opening_hours": "Tu, Fr 07:30-14:00",
         "location": "Vor der Heilig-Geist-Kirche",
         "coordinates": [49.0046859, 8.3323837]
     },
     "Durlach": {
-        "days": [
-            [[7, 30], [14, 0]],
-            [[7, 30], [14, 0]],
-            [[7, 30], [14, 0]],
-            [[7, 30], [14, 0]],
-            [[7, 30], [14, 0]],
-            [[7, 30], [14, 0]],
-            null
-        ],
         "opening_hours": "Mo-Sa 07:30-14:00",
         "location": "Auf dem Marktplatz",
         "coordinates": [48.9991056, 8.4714722]
     },
     "Gottesauer Platz": {
-        "days": [
-            [[7, 30], [14, 0]],
-            null,
-            [[7, 30], [14, 0]],
-            null,
-            [[7, 30], [14, 0]],
-            null,
-            null
-        ],
         "opening_hours": "Mo, We, Fr 07:30-14:00",
         "location": null,
         "coordinates": [49.0074213, 8.4237841]
     },
     "Gutenbergplatz": {
-        "days": [
-            null,
-            [[7, 30], [14, 0]],
-            null,
-            [[7, 30], [14, 0]],
-            null,
-            [[7, 30], [14, 0]],
-            null
-        ],
         "opening_hours": "Tu, Th, Sa 07:30-14:00",
         "location": null,
         "coordinates": [49.008835, 8.375717]
     },
     "Grünwinkel": {
-        "days": [
-            null,
-            null,
-            null,
-            [[14, 0], [18, 30]],
-            null,
-            null,
-            null
-        ],
         "opening_hours": "Th 14:00-18:30",
         "location": "Auf dem Robert-Sinner-Platz",
         "coordinates": [49.00252, 8.35588]
     },
     "Knielingen": {
-        "days": [
-            null,
-            null,
-            [[7, 30], [14, 0]],
-            null,
-            [[7, 30], [16, 0]],
-            [[7, 30], [14, 0]],
-            null
-        ],
         "opening_hours": "We, Sa 07:30-14:00; Fr 07:30-16:00",
         "location": "Auf dem Elsässer Platz",
         "coordinates": [49.030625, 8.340640]
     },
     "Kronenplatz": {
-        "days": [
-            [[9, 0], [20, 0]],
-            [[9, 0], [20, 0]],
-            [[9, 0], [20, 0]],
-            [[9, 0], [20, 0]],
-            [[9, 0], [20, 0]],
-            [[9, 0], [16, 0]],
-            null
-        ],
         "opening_hours": "Mo-Fr 09:00-20:00; Sa 09:00-16:00",
         "location": null,
         "coordinates": [49.008690, 8.409358]
     },
     "Mühlburg": {
-        "days": [
-            null,
-            null,
-            null,
-            null,
-            [[7, 30], [14, 0]],
-            null,
-            null
-        ],
         "opening_hours": "Fr 07:30-14:00",
         "location": "Am Entenfang",
         "coordinates": [49.010222, 8.358549]
     },
     "Neureut": {
-        "days": [
-            null,
-            null,
-            null,
-            null,
-            [[7, 30], [18, 0]],
-            null,
-            null
-        ],
         "opening_hours": "Fr 07:30-18:00",
         "location": "Auf dem Neureuter Platz",
         "coordinates": [49.0445057, 8.382284]
     },
     "Nordweststadt": {
-        "days": [
-            null,
-            [[7, 30], [14, 0]],
-            null,
-            null,
-            null,
-            [[7, 30], [14, 0]],
-            null
-        ],
         "opening_hours": "Tu, Sa 07:30-14:00",
         "location": "Auf dem Walther-Rathenau-Platz",
         "coordinates": [49.0291955, 8.3700837]
     },
     "Oberreut": {
-        "days": [
-            null,
-            null,
-            null,
-            null,
-            [[14, 0], [18, 30]],
-            null,
-            null
-        ],
         "opening_hours": "Fr 14:00-18:30",
         "location": "Auf dem Julius-Leber-Platz",
         "coordinates": [48.9857738, 8.3621401]
     },
     "Rüppurr": {
-        "days": [
-            null,
-            null,
-            [[7, 30], [14, 0]],
-            null,
-            null,
-            [[7, 30], [14, 0]],
-            null
-        ],
         "opening_hours": "We, Sa 07:30-14:00",
         "location": "Vor der Christ-König-Kirche",
         "coordinates": [48.9713553, 8.4050009]
     },
     "Stephanplatz": {
-        "days": [
-            [[7, 30], [14, 0]],
-            null,
-            [[7, 30], [14, 0]],
-            null,
-            [[7, 30], [14, 0]],
-            null,
-            null
-        ],
         "opening_hours": "Mo, We, Fr 07:30-14:00",
         "location": null,
         "coordinates": [49.0086757, 8.3940901]
     },
     "Waldstadt": {
-        "days": [
-            null,
-            null,
-            [[14, 0], [18, 30]],
-            null,
-            [[12, 0], [18, 30]],
-            [[7, 30], [14, 0]],
-            null
-        ],
         "opening_hours": "We 14:00-18:30; Fr 12:00-18:30; Sa 07:30-14:00",
         "location": "Am Waldstadtzentrum",
         "coordinates": [49.0347051, 8.4441821]
     },
     "Werderplatz": {
-        "days": [
-            null,
-            [[7, 30], [14, 0]],
-            null,
-            null,
-            [[7, 30], [14, 0]],
-            [[7, 30], [14, 0]],
-            null
-        ],
         "opening_hours": "Tu, Fr, Sa 07:30-14:00",
         "location": null,
         "coordinates": [49.0015128, 8.4069493]

--- a/markt.json
+++ b/markt.json
@@ -9,6 +9,7 @@
             null,
             null
         ],
+        "opening_hours": "We 07:30-14:00",
         "location": "Am Saumarkt",
         "coordinates": [48.9988247, 8.4708768]
     },
@@ -22,6 +23,7 @@
             null,
             null
         ],
+        "opening_hours": "Tu, Fr 07:30-14:00",
         "location": "Vor der Heilig-Geist-Kirche",
         "coordinates": [49.0046859, 8.3323837]
     },
@@ -35,6 +37,7 @@
             [[7, 30], [14, 0]],
             null
         ],
+        "opening_hours": "Mo-Sa 07:30-14:00",
         "location": "Auf dem Marktplatz",
         "coordinates": [48.9991056, 8.4714722]
     },
@@ -48,6 +51,7 @@
             null,
             null
         ],
+        "opening_hours": "Mo, We, Fr 07:30-14:00",
         "location": null,
         "coordinates": [49.0074213, 8.4237841]
     },
@@ -61,6 +65,7 @@
             [[7, 30], [14, 0]],
             null
         ],
+        "opening_hours": "Tu, Th, Sa 07:30-14:00",
         "location": null,
         "coordinates": [49.008835, 8.375717]
     },
@@ -74,6 +79,7 @@
             null,
             null
         ],
+        "opening_hours": "Th 14:00-18:30",
         "location": "Auf dem Robert-Sinner-Platz",
         "coordinates": [49.00252, 8.35588]
     },
@@ -87,6 +93,7 @@
             [[7, 30], [14, 0]],
             null
         ],
+        "opening_hours": "We, Sa 07:30-14:00; Fr 07:30-16:00",
         "location": "Auf dem Elsässer Platz",
         "coordinates": [49.030625, 8.340640]
     },
@@ -100,6 +107,7 @@
             [[9, 0], [16, 0]],
             null
         ],
+        "opening_hours": "Mo-Fr 09:00-20:00; Sa 09:00-16:00",
         "location": null,
         "coordinates": [49.008690, 8.409358]
     },
@@ -113,6 +121,7 @@
             null,
             null
         ],
+        "opening_hours": "Fr 07:30-14:00",
         "location": "Am Entenfang",
         "coordinates": [49.010222, 8.358549]
     },
@@ -126,6 +135,7 @@
             null,
             null
         ],
+        "opening_hours": "Fr 07:30-18:00",
         "location": "Auf dem Neureuter Platz",
         "coordinates": [49.0445057, 8.382284]
     },
@@ -139,6 +149,7 @@
             [[7, 30], [14, 0]],
             null
         ],
+        "opening_hours": "Tu, Sa 07:30-14:00",
         "location": "Auf dem Walther-Rathenau-Platz",
         "coordinates": [49.0291955, 8.3700837]
     },
@@ -152,6 +163,7 @@
             null,
             null
         ],
+        "opening_hours": "Fr 14:00-18:30",
         "location": "Auf dem Julius-Leber-Platz",
         "coordinates": [48.9857738, 8.3621401]
     },
@@ -165,6 +177,7 @@
             [[7, 30], [14, 0]],
             null
         ],
+        "opening_hours": "We, Sa 07:30-14:00",
         "location": "Vor der Christ-König-Kirche",
         "coordinates": [48.9713553, 8.4050009]
     },
@@ -178,6 +191,7 @@
             null,
             null
         ],
+        "opening_hours": "Mo, We, Fr 07:30-14:00",
         "location": null,
         "coordinates": [49.0086757, 8.3940901]
     },
@@ -191,6 +205,7 @@
             [[7, 30], [14, 0]],
             null
         ],
+        "opening_hours": "We 14:00-18:30; Fr 12:00-18:30; Sa 07:30-14:00",
         "location": "Am Waldstadtzentrum",
         "coordinates": [49.0347051, 8.4441821]
     },
@@ -204,6 +219,7 @@
             [[7, 30], [14, 0]],
             null
         ],
+        "opening_hours": "Tu, Fr, Sa 07:30-14:00",
         "location": null,
         "coordinates": [49.0015128, 8.4069493]
     }


### PR DESCRIPTION
I have rewritten the format for storing **opening hours** to [what OpenStreetMap is using](http://wiki.openstreetmap.org/wiki/Key:opening_hours). This should make it easier to integrate other data sources such as for other cities as proposed in issue #3. Further work follows.
