### PR TITLE
Unclassified opening hours

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -183,7 +183,7 @@ function initMarker(feature) {
     var properties = feature.properties;
     var opening_hours_strings = properties.opening_hours;
     if (opening_hours_strings === undefined) {
-        throw "Missing property 'opening_hours' for " + properties.title + ".";
+        throw "Missing property 'opening_hours' for " + properties.title + " (" + properties.location + ").";
     }
     var openingRanges = getOpeningRanges(opening_hours_strings);
     var todayOpeningRange = getOpeningRangeForDate(openingRanges, now);

--- a/js/main.js
+++ b/js/main.js
@@ -10,6 +10,7 @@ var map;
 var nowGroup = L.layerGroup();
 var todayGroup = L.layerGroup();
 var otherGroup = L.layerGroup();
+var unclassifiedGroup = L.layerGroup();
 
 var now = new Date();
 var TIME_NOW = [now.getHours(), now.getMinutes()];
@@ -21,6 +22,7 @@ L.AwesomeMarkers.Icon.prototype.options.prefix = 'fa';
 var nowIcon = L.AwesomeMarkers.icon({markerColor: 'green', icon: 'shopping-cart'});
 var todayIcon = L.AwesomeMarkers.icon({markerColor: 'darkgreen', icon: 'shopping-cart'});
 var otherIcon = L.AwesomeMarkers.icon({markerColor: 'cadetblue', icon: 'shopping-cart'});
+var unclassifiedIcon = L.AwesomeMarkers.icon({markerColor: 'darkpurple', icon: 'shopping-cart'});
 
 /*
  * Return 0-padded string of a number.
@@ -185,8 +187,16 @@ function initMarker(feature) {
     if (opening_hours_strings === undefined) {
         throw "Missing property 'opening_hours' for " + properties.title + " (" + properties.location + ").";
     }
-    var openingRanges = getOpeningRanges(opening_hours_strings);
-    var todayOpeningRange = getOpeningRangeForDate(openingRanges, now);
+    var todayOpeningRange = undefined;
+    var timeTableHtml = undefined;
+    var opening_hours_unclassified = undefined;
+    if (opening_hours_strings === null || opening_hours_strings.length == 0) {
+        opening_hours_unclassified = properties.opening_hours_unclassified;
+    } else {
+        var openingRanges = getOpeningRanges(opening_hours_strings);
+        todayOpeningRange = getOpeningRangeForDate(openingRanges, now);
+        timeTableHtml = getTimeTable(openingRanges);
+    }
 
     var coordinates = feature.geometry.coordinates;
     var marker = L.marker(L.latLng(coordinates[1], coordinates[0]));
@@ -206,8 +216,12 @@ function initMarker(feature) {
     if (title === null || title.length == 0) {
         title = DEFAULT_MARKET_TITLE;
     }
-    var timeTableHtml = getTimeTable(openingRanges);
-    var popupHtml = '<h1>' + title + '</h1>' + where + timeTableHtml;
+    var popupHtml = '<h1>' + title + '</h1>' + where;
+    if (opening_hours_unclassified !== undefined) {
+        popupHtml += '<p class="unclassified">' + opening_hours_unclassified + '</p>';
+    } else {
+        popupHtml += timeTableHtml;
+    }
     marker.bindPopup(popupHtml);
     if (todayOpeningRange !== undefined) {
         if (openingRangeContainsTime(todayOpeningRange, now)) {
@@ -218,8 +232,13 @@ function initMarker(feature) {
             todayGroup.addLayer(marker);
         }
     } else {
-        marker.setIcon(otherIcon);
-        otherGroup.addLayer(marker);
+        if (opening_hours_unclassified !== undefined) {
+            marker.setIcon(unclassifiedIcon);
+            unclassifiedGroup.addLayer(marker);
+        } else {
+            marker.setIcon(otherIcon);
+            otherGroup.addLayer(marker);
+        }
     }
 }
 
@@ -240,6 +259,7 @@ $(document).ready(function() {
     $.getJSON("maerkte-karlsruhe.json", function(json) {
         initMarkers(json);
         initControls();
+        map.addLayer(unclassifiedGroup);
         map.addLayer(nowGroup);
         updateLayers();
     });

--- a/styles/main.css
+++ b/styles/main.css
@@ -87,3 +87,8 @@ table.times tr.today * {
 .leaflet-popup-content p {
     margin: 0;
 }
+
+.leaflet-popup-content p.unclassified {
+    margin-top: 0.5em;
+    font-style: italic;
+}


### PR DESCRIPTION
In this branch I add the option to specify opening hours in the GeoJSON file which cannot be parsed automatically. Such locations are organized in a separate "unclassified" group. Humans can thereby interpret the available information. The screenshot shows such a location with unclassified opening hours.

![Location with unclassified opening hours](https://cloud.githubusercontent.com/assets/144518/12393775/352be2ba-bdf8-11e5-958d-2a53879f70d5.png)

Please note that this change does actually not affect information being displayed for Karlsruhe.
